### PR TITLE
handle for null channel NPE when close() is called

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/chrome_custom_tabs/ChromeCustomTabsActivity.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/chrome_custom_tabs/ChromeCustomTabsActivity.java
@@ -275,6 +275,8 @@ public class ChromeCustomTabsActivity extends Activity implements MethodChannel.
     customTabsSession = null;
     finish();
     Map<String, Object> obj = new HashMap<>();
-    channel.invokeMethod("onChromeSafariBrowserClosed", obj);
+    if(channel != null) {
+      channel.invokeMethod("onChromeSafariBrowserClosed", obj);
+    }
   }
 }


### PR DESCRIPTION
In our crashlytics we are getting this bug: https://console.firebase.google.com/project/bash-2127d/crashlytics/app/android:com.bash.prod/issues/858604c3e441ab4b99c95085523b3c51?time=last-seven-days&sessionEventKey=63F5E8AC01600001348F2981FCB66A8D_1781364613945673814

Whereby the channel is null when trying to call `invokeMethod()` and throwing an NPE. Wrapping the `channel.invokeMethod()` in a null check for safety.